### PR TITLE
Add default cache headers

### DIFF
--- a/.github/workflows/flask-base.yml
+++ b/.github/workflows/flask-base.yml
@@ -13,7 +13,7 @@ jobs:
         python-version: 3.6
         
     - name: Install dependencies
-      run: pip install black flake8
+      run: pip3 install black flake8
 
     - name: Flake
       run: flake8 canonicalwebteam tests
@@ -31,12 +31,8 @@ jobs:
         python-version: 3.6
         
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install poetry
-        poetry config settings.virtualenvs.create false
-        poetry install
+      run: pip3 install .
 
     - name: Test
-      run: python -m unittest discover tests
+      run: python3 -m unittest discover tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.4.0 (2020-02-10)
+
+### Added
+Set cache headers for all responses, overridable in the view.
+
+
 # 0.2.0 (2019-06-10)
 
 ### Features

--- a/canonicalwebteam/flask_base/app.py
+++ b/canonicalwebteam/flask_base/app.py
@@ -99,6 +99,10 @@ class FlaskBase(flask.Flask):
                 return flask.render_template(template_500), 500
 
         # Default routes
+        @self.route("/_status/check")
+        def status_check():
+            return os.getenv("TALISKER_REVISION_ID", "OK")
+
         if favicon_url:
 
             @self.route("/favicon.ico")

--- a/canonicalwebteam/flask_base/app.py
+++ b/canonicalwebteam/flask_base/app.py
@@ -19,6 +19,19 @@ from canonicalwebteam.yaml_responses.flask_helpers import (
 )
 
 
+def set_cache_control_headers(response):
+    if flask.request.path.startswith("/_status"):
+        response.cache_control.no_store = True
+        response.cache_control.max_age = 0
+    elif not response.cache_control:
+        # response.cache_control does not support stale_while_revalidate so...
+        response.headers[
+            "Cache-Control"
+        ] = "public, max-age=300, stale-while-revalidate=360"
+
+    return response
+
+
 class FlaskBase(flask.Flask):
     def __init__(
         self,
@@ -64,6 +77,8 @@ class FlaskBase(flask.Flask):
                 path=os.path.join(self.root_path, "..", "deleted.yaml")
             )
         )
+
+        self.after_request(set_cache_control_headers)
 
         self.context_processor(base_context)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.flask_base"
-version = "0.3.3"
+version = "0.4"
 description = ""
 authors = ["Canonical webteam <webteam@canonical.com>"]
 packages = [{ include = "canonicalwebteam" }]

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     name='canonicalwebteam.flask-base',  # Required
     # https://www.python.org/dev/peps/pep-0440/
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.3.3',  # Required
+    version='0.4',  # Required
     # https://packaging.python.org/specifications/core-metadata/#summary
     description="",  # Required
     # https://packaging.python.org/specifications/core-metadata/#description-optional

--- a/tests/test_app/webapp/app.py
+++ b/tests/test_app/webapp/app.py
@@ -19,6 +19,24 @@ def create_test_app():
     def page():
         return "page"
 
+    @app.route("/auth")
+    def auth():
+        flask.session["test"] = True
+        return "auth", 200
+
+    @app.route("/cache")
+    def cache():
+        response = flask.make_response()
+        response.cache_control.public = True
+        response.cache_control.max_age = 1000
+
+        return response, 200
+
+    @app.route("/_status/test")
+    @app.route("/_status/check")
+    def status():
+        return "_status", 200
+
     @app.route("/error")
     def error_route():
         flask.abort(500)

--- a/tests/test_app/webapp/app.py
+++ b/tests/test_app/webapp/app.py
@@ -32,11 +32,6 @@ def create_test_app():
 
         return response, 200
 
-    @app.route("/_status/test")
-    @app.route("/_status/check")
-    def status():
-        return "_status", 200
-
     @app.route("/error")
     def error_route():
         flask.abort(500)

--- a/tests/test_flask_base.py
+++ b/tests/test_flask_base.py
@@ -52,6 +52,41 @@ class TestFlaskBase(unittest.TestCase):
         app = self.create_app()
         self.assertIsInstance(app.wsgi_app, ProxyFix)
 
+    def test_default_cache_headers(self):
+        with create_test_app().test_client() as client:
+            cached_response = client.get("page")
+            self.assertEqual(
+                cached_response.headers.get("Cache-Control"),
+                "public, max-age=300, stale-while-revalidate=360",
+            )
+
+    def test_vary_cookie_when_session(self):
+        with create_test_app().test_client() as client:
+            cached_response_with_session = client.get("auth")
+            self.assertEqual(
+                cached_response_with_session.headers.get("Vary"), "Cookie"
+            )
+
+    def test_cache_does_not_overide(self):
+        with create_test_app().test_client() as client:
+            cached_response = client.get("cache")
+            self.assertEqual(
+                cached_response.headers.get("Cache-Control"),
+                "public, max-age=1000",
+            )
+
+    def test_status_endpoints_no_cache(self):
+        with create_test_app().test_client() as client:
+            response = client.get("_status/check")
+            self.assertEqual(
+                response.headers.get("Cache-Control"), "no-store, max-age=0"
+            )
+
+            response = client.get("_status/test")
+            self.assertEqual(
+                response.headers.get("Cache-Control"), "no-store, max-age=0"
+            )
+
     def test_redirects_deleted(self):
         """
         Check test_app/{redirects,permanent-redirects,deleted}.yaml

--- a/tests/test_flask_base.py
+++ b/tests/test_flask_base.py
@@ -75,14 +75,12 @@ class TestFlaskBase(unittest.TestCase):
                 "public, max-age=1000",
             )
 
-    def test_status_endpoints_no_cache(self):
+    def test_status_endpoints(self):
         with create_test_app().test_client() as client:
+            os.environ["TALISKER_REVISION_ID"] = "a-build-id"
             response = client.get("_status/check")
-            self.assertEqual(
-                response.headers.get("Cache-Control"), "no-store, max-age=0"
-            )
-
-            response = client.get("_status/test")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.data.decode(), "a-build-id")
             self.assertEqual(
                 response.headers.get("Cache-Control"), "no-store, max-age=0"
             )


### PR DESCRIPTION
# Done
Add a default strategy to add cache headers to all flask-base responses.

# QA
- Verify the tests I wrote make sense
- Make sure the tests pass

# Issues
https://github.com/canonical-web-and-design/web-squad/issues/2312