### PR TITLE
Serve favicon from root if it exists, otherwise fallback to favicon url.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.6.1 (2020-05-20)
+
+### Features
+Serve favicon from static if it exists, otherwise fallback to favicon url.
+
 # 0.6.0 (2020-04-14)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -76,15 +76,6 @@ You get two jinja2 helpers to use in your templates from flask-base:
 
 If you create a `robots.txt` or `humans.txt` in the root of your project, these will be served at `/robots.txt` and `/humans.txt` respectively.
 
-## Generating setup.py
-
-In this project, for the time being, we maintain both a `pyproject.toml` for Poetry and a `setup.py` for traditional Python tooling. If you are developing on the module, you should update `pyproject.toml` first and then regenerate the `setup.py` using:
-
-```bash
-poetry install
-poetry run poetry-setup
-```
-
 ## Tests
 
-To run the tests execute `SECRET_KEY=fake poetry run python -m unittest discover tests`.
+To run the tests execute `SECRET_KEY=fake python3 -m unittest discover tests`.

--- a/canonicalwebteam/flask_base/app.py
+++ b/canonicalwebteam/flask_base/app.py
@@ -103,7 +103,16 @@ class FlaskBase(flask.Flask):
         def status_check():
             return os.getenv("TALISKER_REVISION_ID", "OK")
 
-        if favicon_url:
+        favicon_path = os.path.join(self.root_path, "../static", "favicon.ico")
+        if os.path.isfile(favicon_path):
+
+            @self.route("/favicon.ico")
+            def favicon():
+                return flask.send_file(
+                    favicon_path, mimetype="image/vnd.microsoft.icon"
+                )
+
+        elif favicon_url:
 
             @self.route("/favicon.ico")
             def favicon():

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="canonicalwebteam.flask-base",
-    version="0.6.0",
+    version="0.6.1",
     description="",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_flask_base.py
+++ b/tests/test_flask_base.py
@@ -167,6 +167,18 @@ class TestFlaskBase(unittest.TestCase):
                 "http://localhost" + local_url,
             )
 
+    def test_favicon_serve(self):
+        """
+        If `favicon_url` is provided, check requests to `/favicon.ico`
+        receive a redirect
+        """
+
+        local_app = create_test_app()
+
+        with local_app.test_client() as client:
+            response = client.get("/favicon.ico")
+            self.assertEqual(200, response.status_code)
+
     def test_robots_humans(self):
         """
         If `robots.txt` and `humans.txt` are provided at the root of the


### PR DESCRIPTION
## Done
Serve favicon from root if it exists, otherwise fallback to favicon url.

## QA
Done in https://github.com/canonical-web-and-design/ubuntu.com/pull/7539