### PR TITLE
v0.6.2: Dont break the app if versioned_static cant find files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.6.2 (2020-06-11)
+
+### Fix
+`versioned_static` shouldn't break the app if files are missing
+
+
 # 0.6.1 (2020-05-20)
 
 ### Features

--- a/canonicalwebteam/flask_base/context.py
+++ b/canonicalwebteam/flask_base/context.py
@@ -19,10 +19,12 @@ def versioned_static(filename):
     with a hex hash as a query string for versioning
     """
     static_path = current_app.static_folder
+    static_url = current_app.static_url_path
 
     file_path = os.path.join(static_path, filename)
     if not os.path.isfile(file_path):
-        raise
+        # File is missing, simply return the string so we don't break anything
+        return f"{static_url}/{filename}?v=file-not-found"
 
     # Use MD5 as we care about speed a lot
     # and not security in this case
@@ -30,8 +32,6 @@ def versioned_static(filename):
     with open(file_path, "rb") as file_contents:
         for chunk in iter(lambda: file_contents.read(4096), b""):
             file_hash.update(chunk)
-
-    static_url = current_app.static_url_path
 
     return f"{static_url}/{filename}?v={file_hash.hexdigest()[:7]}"
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os import path
 
 setup(
     name="canonicalwebteam.flask-base",
-    version="0.6.1",
+    version="0.6.2",
     description=(
         "Flask extension that applies common configurations"
         "to all of webteam's flask apps."


### PR DESCRIPTION
If a file isn't found, don't break everything

We were throwing an error whenever a file was missing, which is way too
drastic.

This instead makes it simple output the file path like normal, but with a
`?v=file-not-found` appended, so nothing breaks.