### PR TITLE
Update static files cache TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.7.0 (2020-11-18)
+
+### Added
+Set `SEND_FILE_MAX_AGE_DEFAULT` to a year (31536000)
+
 # 0.6.4 (2020-09-22)
 
 ### Added

--- a/canonicalwebteam/flask_base/app.py
+++ b/canonicalwebteam/flask_base/app.py
@@ -48,6 +48,7 @@ class FlaskBase(flask.Flask):
         self.service = service
 
         self.config["SECRET_KEY"] = os.environ["SECRET_KEY"]
+        self.config["SEND_FILE_MAX_AGE_DEFAULT"] = 31536000
 
         self.url_map.strict_slashes = False
         self.url_map.converters["regex"] = RegexConverter

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.flask-base",
-    version="0.6.4",
+    version="0.7.0",
     description=(
         "Flask extension that applies common configurations"
         "to all of webteam's flask apps."


### PR DESCRIPTION
Update default cache control header for static files to a year.

https://flask.palletsprojects.com/en/1.1.x/config/#SEND_FILE_MAX_AGE_DEFAULT