### PR TITLE
Disable interest-cohort for privacy reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.0 (2021-04-15)
+
+Add header: `Permissions-Policy: interest-cohort=()` that disables FLoC for privacy reasons.
+
 # 0.8.0 (2021-03-19)
 
 Change default caching headers to `cache-control: max-age=60, stale-while-revalidate=86400, stale-if-error=300`.

--- a/canonicalwebteam/flask_base/app.py
+++ b/canonicalwebteam/flask_base/app.py
@@ -125,6 +125,18 @@ def set_cache_control_headers(response):
     return response
 
 
+def set_permissions_policy_headers(response):
+    """
+    Sets default permissions policies. This disable some browsers features
+    and APIs.
+    """
+    # Disabling interest-cohort for privacy reasons.
+    # https://wicg.github.io/floc/
+    response.headers["Permissions-Policy"] = "interest-cohort=()"
+
+    return response
+
+
 class FlaskBase(flask.Flask):
     def __init__(
         self,
@@ -173,6 +185,7 @@ class FlaskBase(flask.Flask):
 
         self.after_request(set_security_headers)
         self.after_request(set_cache_control_headers)
+        self.after_request(set_permissions_policy_headers)
 
         self.context_processor(base_context)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.flask-base",
-    version="0.8.0",
+    version="0.9.0",
     description=(
         "Flask extension that applies common configurations"
         "to all of webteam's flask apps."


### PR DESCRIPTION
# Summary

- Google is currently testing "Federated Learning of Cohorts (FLoC)" on the chrome browser, a new way to track users.
- It is quite invasive for privacy reasons:
  - https://spreadprivacy.com/block-floc-with-duckduckgo/
  - https://www.eff.org/deeplinks/2021/03/googles-floc-terrible-idea
- Some other companies have already stepped up to disable FLoC on their sites (eg. https://www.theguardian.com/uk )
- I believe that for privacy reasons and while it is still being built we should step in the discussion and disable the access from the browsers API to this feature
- It is possible to disable some browsers features and API with using the "Permissions policy" header.
  - To disable FLoC we should disable the feature:  `interest-cohort`
- More informations to read:
  - [permissions-policy](https://www.w3.org/TR/permissions-policy-1/#introduction)
  - [Google proposal for FLoC](https://wicg.github.io/floc/)