### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.0 (2021-10-27)
+
+Upgrade dependencies: Werkzeug and gevent.
+
 # 0.9.3 (2021-10-27)
 
 Include PID on Talisker logs

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     install_requires=[
         "canonicalwebteam.yaml-responses[flask] (>=1,<2)",
         "flask (>=1,<2)",
-        "gevent==21.8.0",
+        "gevent==21.12.0",
         "greenlet==1.1.2",
         "talisker[gunicorn,gevent,flask,prometheus,raven]==0.19.0",
         "Werkzeug (>=1.0.0, <1.2)",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.flask-base",
-    version="0.9.3",
+    version="1.0.0",
     description=(
         "Flask extension that applies common configurations"
         "to all of webteam's flask apps."
@@ -25,7 +25,7 @@ setup(
         "gevent==21.8.0",
         "greenlet==1.1.2",
         "talisker[gunicorn,gevent,flask,prometheus,raven]==0.19.0",
-        "Werkzeug (>=0.15,<0.16)",
+        "Werkzeug (>=1.0.0, <1.2)",
     ],
     dependency_links=[],
     include_package_data=True,


### PR DESCRIPTION
Werkzeug
- Upgraded to v1 mainly to allow us to set cookies with `SameSite=None`. See https://github.com/pallets/werkzeug/issues/1549, there are some issues recently with Firefox, see https://bugs.launchpad.net/canonical-identity-provider/+bug/1895734/ 
- `<1.2` to match with Talisker dependency requirements.

gevent
- Upgraded to latest version.

## QA
https://github.com/canonical-web-and-design/snapcraft.io/pull/3869
