### PR TITLE
Pass through error messages to templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.2 (2022-03-21)
+
+Pass through error messages from flask.abort to 404.html and 500.html templates
+
 # 1.0.1 (2022-02-21)
 
 Fix dependencies for Flask 1.1.x: markupsafe and itsdangerous.

--- a/canonicalwebteam/flask_base/app.py
+++ b/canonicalwebteam/flask_base/app.py
@@ -232,13 +232,23 @@ class FlaskBase(flask.Flask):
 
             @self.errorhandler(404)
             def not_found_error(error):
-                return flask.render_template(template_404), 404
+                return (
+                    flask.render_template(
+                        template_404, message=error.description
+                    ),
+                    404,
+                )
 
         if template_500:
 
             @self.errorhandler(500)
             def internal_error(error):
-                return flask.render_template(template_500), 500
+                return (
+                    flask.render_template(
+                        template_500, message=error.description
+                    ),
+                    500,
+                )
 
         # Default routes
         @self.route("/fish")

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.flask-base",
-    version="1.0.1",
+    version="1.0.2",
     description=(
         "Flask extension that applies common configurations"
         "to all of webteam's flask apps."


### PR DESCRIPTION
This is to support https://github.com/canonical-web-and-design/ubuntu.com/pull/11343.

`flask.abort` [can take a second argument](https://flask-restplus.readthedocs.io/en/stable/errors.html#the-flask-abort-helper), which is supposed to be the error description for the error handler. It seems like this should be passed through to the error templates if it's defined. Which is what I try to do in that PR.

QA
--

QA by QAing https://github.com/canonical-web-and-design/ubuntu.com/pull/11343 which installs from this branch.