### PR TITLE
Add GitHub URL to package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
+    url="https://github.com/canonical-web-and-design/canonicalwebteam.flask-base",
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
Based on how it is done in our search module:

https://github.com/canonical-web-and-design/canonicalwebteam.search/blob/1957f0bdf6659723c8e6ab7368e2bf3deb0944a0/setup.py#L10

This should make sure pypi and renovate can correctly identify the repo of the project.