### PR TITLE
Set X-Clacks-Overhead to keep Terry Pratchett in the network

### DIFF
--- a/canonicalwebteam/flask_base/app.py
+++ b/canonicalwebteam/flask_base/app.py
@@ -135,6 +135,17 @@ def set_permissions_policy_headers(response):
     return response
 
 
+def set_clacks(response):
+    """
+    Keep Sir Terry Pratchett's name alive
+    https://xclacksoverhead.org/home/about
+    """
+
+    response.headers["X-Clacks-Overhead"] = "GNU Terry Pratchett"
+
+    return response
+
+
 class FlaskBase(flask.Flask):
     def send_static_file(self, filename: str) -> "flask.wrappers.Response":
         """
@@ -219,6 +230,7 @@ class FlaskBase(flask.Flask):
         self.after_request(set_security_headers)
         self.after_request(set_cache_control_headers)
         self.after_request(set_permissions_policy_headers)
+        self.after_request(set_clacks)
 
         self.context_processor(base_context)
 


### PR DESCRIPTION
From https://xclacksoverhead.org/home/about:

> In Sir Terry's novel "Going Postal", the story explains that the inventor of the Clacks - a man named Robert Dearheart, lost his only son in a suspicious workplace accident, and in order to keep the memory of his son alive, he transmitted his son's name as a special operational signal through the Clacks to forever preserve his memory:
>
> GNU John Dearheart
>
> G: Send the message onto the next Clacks Tower.
>
> N: Do not log the message.
>
> U: At the end of the line, return the message.
>
> The nature of the 'GNU' code would keep the name of his son forever transmitting through The Clacks network so long as the network still existed.
>
> "A man is not dead while his name is still spoken."

...

> At the time of writing, Mozilla.org (makers of the Firefox web browser), the makers of Debian (a popular Linux Operation System), and Xml.com (a major repository of standards information) are examples of some of the backbones of the Internet who transmit the Signal "GNU Terry Pratchett". The Internet news website The Register also transmits headers to commemorate both Sir Terry Pratchett and one of their staffers; Lester Haines.
