### PR TITLE
add SENTRY_DSN env var

### DIFF
--- a/canonicalwebteam/flask_base/app.py
+++ b/canonicalwebteam/flask_base/app.py
@@ -216,7 +216,7 @@ class FlaskBase(flask.Flask):
 
         # Ensure that either SECRET_KEY or FLASK_SECRET_KEY is set
         self.config["SECRET_KEY"] = get_flask_env("SECRET_KEY", error=True)
-        self.config["SENTRY_DSN"] = get_flask_env("SENTRY_DSN", error=True)
+        self.config["SENTRY_DSN"] = get_flask_env("SENTRY_DSN")
         # Load environment variables prefixed with 'FLASK_' into the
         # environment as regular variables
         load_plain_env_variables()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="canonicalwebteam.flask-base",
-    version="2.6.0",
+    version="2.6.1",
     description=(
         "Flask extension that applies common configurations"
         "to all of webteam's flask apps."


### PR DESCRIPTION
- Add SENTRY_DSN to env variables by capturing its value using the `get_flask_env` method
- sentry dsn requires the above env variable to be set in order to connect to it